### PR TITLE
feat: Pull add useBodyScroll api

### DIFF
--- a/components/pull/PropsType.tsx
+++ b/components/pull/PropsType.tsx
@@ -32,4 +32,5 @@ export interface PropsType {
   animationDuration?: number;
   stayTime?: number;
   locale?: Locale['Pull'];
+  useBodyScroll?: boolean;
 }

--- a/components/pull/Pull.tsx
+++ b/components/pull/Pull.tsx
@@ -32,6 +32,7 @@ export default class Pull extends PureComponent<PullProps, any> {
     },
     animationDuration: 400,
     stayTime: 1000,
+    useBodyScroll: false,
   };
 
   constructor(props) {
@@ -86,6 +87,9 @@ export default class Pull extends PureComponent<PullProps, any> {
   }
 
   getScrollContainer = () => {
+    if (this.props.useBodyScroll) {
+      return document.documentElement;
+    }
     return ((node) => {
       while (node && node.parentNode && node.parentNode !== document.body) {
         const style = window.getComputedStyle(node);

--- a/components/pull/demo.md
+++ b/components/pull/demo.md
@@ -185,6 +185,7 @@ ReactDOM.render(<Demo />, mountNode);
 | load | Action | - | 上拉加载的参数配置 |
 | animationDuration | number | 400 | 动画执行时间，单位：毫秒 |
 | stayTime | number | 1000 | 加载成功停留时间 |
+| useBodyScroll | boolean | false | 使用 html 的 `body` 作为滚动容器 |
 
 ### Action 类型定义
 | 属性 | 类型 | 默认值 | 说明 |


### PR DESCRIPTION
Pull组件新增 `useBodyScroll`，默认为 `false`, 当为 `true` 时，指定html的 `body` 作为滚动容器。

增加这个api的原因在于，移动端将 `body` 作为列表滚动容器是十分常见的场景，直接设定`useBodyScroll` 指定滚动容器，可以减少获取滚动容器的计算开销。