### PR TITLE
feat：为 date-picker-view、picker-view、wheel 组件增加配置项允许修改 better-scroll 的参数（如：swipeTime）

### DIFF
--- a/components/date-picker-view/PropsType.tsx
+++ b/components/date-picker-view/PropsType.tsx
@@ -14,5 +14,5 @@ export default interface BaseDatePickerViewProps {
   valueMember?: string;
   onTransition?: (value: boolean) => void;
   locale?: Locale['DatePickerView'] & Locale['DatePicker'] & Locale['DateSelect'];
-  rollDuration: number;
+  rollDuration?: number;
 }

--- a/components/date-picker-view/PropsType.tsx
+++ b/components/date-picker-view/PropsType.tsx
@@ -14,5 +14,5 @@ export default interface BaseDatePickerViewProps {
   valueMember?: string;
   onTransition?: (value: boolean) => void;
   locale?: Locale['DatePickerView'] & Locale['DatePicker'] & Locale['DateSelect'];
-  betterScrollOptions?: any;
+  scrollOptions?: any;
 }

--- a/components/date-picker-view/PropsType.tsx
+++ b/components/date-picker-view/PropsType.tsx
@@ -14,4 +14,5 @@ export default interface BaseDatePickerViewProps {
   valueMember?: string;
   onTransition?: (value: boolean) => void;
   locale?: Locale['DatePickerView'] & Locale['DatePicker'] & Locale['DateSelect'];
+  betterScrollOptions?: any;
 }

--- a/components/date-picker-view/PropsType.tsx
+++ b/components/date-picker-view/PropsType.tsx
@@ -14,5 +14,5 @@ export default interface BaseDatePickerViewProps {
   valueMember?: string;
   onTransition?: (value: boolean) => void;
   locale?: Locale['DatePickerView'] & Locale['DatePicker'] & Locale['DateSelect'];
-  scrollOptions?: any;
+  rollDuration: number;
 }

--- a/components/picker-view/PickerView.tsx
+++ b/components/picker-view/PickerView.tsx
@@ -71,7 +71,7 @@ export default class PickerView extends Component<PickerViewProps, PickerViewSta
   };
 
   renderWheel = () => {
-    const { valueMember, itemRender, disabled, scrollOptions } = this.props;
+    const { valueMember, itemRender, disabled, rollDuration } = this.props;
     const { dataSource, value } = this.state;
 
     return dataSource.map((item, index) => (
@@ -84,7 +84,7 @@ export default class PickerView extends Component<PickerViewProps, PickerViewSta
         disabled={disabled}
         onChange={(selected) => this.onValueChange(selected, index)}
         onTransition={(isScrolling) => { this.onTransition(isScrolling); }}
-        scrollOptions={scrollOptions}
+        rollDuration={rollDuration}
       />
     ));
   };

--- a/components/picker-view/PickerView.tsx
+++ b/components/picker-view/PickerView.tsx
@@ -71,7 +71,7 @@ export default class PickerView extends Component<PickerViewProps, PickerViewSta
   };
 
   renderWheel = () => {
-    const { valueMember, itemRender, disabled } = this.props;
+    const { valueMember, itemRender, disabled, scrollOptions } = this.props;
     const { dataSource, value } = this.state;
 
     return dataSource.map((item, index) => (
@@ -84,6 +84,7 @@ export default class PickerView extends Component<PickerViewProps, PickerViewSta
         disabled={disabled}
         onChange={(selected) => this.onValueChange(selected, index)}
         onTransition={(isScrolling) => { this.onTransition(isScrolling); }}
+        scrollOptions={scrollOptions}
       />
     ));
   };

--- a/components/picker-view/PropsType.tsx
+++ b/components/picker-view/PropsType.tsx
@@ -10,4 +10,5 @@ export default interface BasePickerViewProps {
   cols?: number;
   disabled?: boolean;
   onTransition?: (value: boolean) => void;
+  scrollOptions?: any;
 }

--- a/components/picker-view/PropsType.tsx
+++ b/components/picker-view/PropsType.tsx
@@ -10,5 +10,5 @@ export default interface BasePickerViewProps {
   cols?: number;
   disabled?: boolean;
   onTransition?: (value: boolean) => void;
-  scrollOptions?: any;
+  rollDuration?: number;
 }

--- a/components/wheel/PropsType.tsx
+++ b/components/wheel/PropsType.tsx
@@ -7,4 +7,5 @@ export interface BaseWheelProps {
   itemRender?: (item?: { [key: string]: any }) => string;
   disabled?: boolean;
   onTransition?: (value: boolean) => void;
+  scrollOptions?: any;
 }

--- a/components/wheel/PropsType.tsx
+++ b/components/wheel/PropsType.tsx
@@ -7,5 +7,5 @@ export interface BaseWheelProps {
   itemRender?: (item?: { [key: string]: any }) => string;
   disabled?: boolean;
   onTransition?: (value: boolean) => void;
-  scrollOptions?: any;
+  rollDuration?: number;
 }

--- a/components/wheel/Wheel.tsx
+++ b/components/wheel/Wheel.tsx
@@ -37,7 +37,7 @@ export default class Wheel extends Component<WheelProps, any> {
   };
 
   componentDidMount() {
-    const { prefixCls, dataSource, disabled, onTransition, valueMember } = this.props;
+    const { prefixCls, dataSource, disabled, onTransition, valueMember, scrollOptions } = this.props;
     const value = getValue(this.props);
     const initIndex = this.getSelectedIndex(value, dataSource);
     this.BScroll = new BScroll(this.wrapper, {
@@ -47,6 +47,7 @@ export default class Wheel extends Component<WheelProps, any> {
         wheelItemClass: `${prefixCls}-item`,
       },
       probeType: 3,
+      ...scrollOptions
     });
 
     disabled && this.BScroll.disable();

--- a/components/wheel/Wheel.tsx
+++ b/components/wheel/Wheel.tsx
@@ -37,7 +37,7 @@ export default class Wheel extends Component<WheelProps, any> {
   };
 
   componentDidMount() {
-    const { prefixCls, dataSource, disabled, onTransition, valueMember, scrollOptions } = this.props;
+    const { prefixCls, dataSource, disabled, onTransition, valueMember, rollDuration } = this.props;
     const value = getValue(this.props);
     const initIndex = this.getSelectedIndex(value, dataSource);
     this.BScroll = new BScroll(this.wrapper, {
@@ -47,7 +47,7 @@ export default class Wheel extends Component<WheelProps, any> {
         wheelItemClass: `${prefixCls}-item`,
       },
       probeType: 3,
-      ...scrollOptions
+      swipeTime: rollDuration || 2500,
     });
 
     disabled && this.BScroll.disable();


### PR DESCRIPTION

### 目的

如果滚动动画未完成，点击picker select类组件（如DateSelect）确定按钮无任何作用，

目前设置的滚动动画用的是better-scroll的默认（2500ms），很容易出现点击无反应的问题。

### 解决方式

传入参数控制滚动动画的时长。

#426 
