### PR TITLE
fix: remove ART

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "react-intl": "^5.12.1",
     "react-loadable": "^5.5.0",
     "react-native": "^0.63.4",
-    "react-native-mock-render": "0.1.5",
+    "react-native-mock-render": "git+https://github.com/mrdulin/react-native-mock-render.git#art",
     "react-navigation": "^4.0.3",
     "react-router-dom": "^5.1.2",
     "rimraf": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12980,10 +12980,9 @@ react-native-camera-roll-picker@1.2.3:
   resolved "https://registry.yarnpkg.com/react-native-camera-roll-picker/-/react-native-camera-roll-picker-1.2.3.tgz#b117fd3a2b9012dcccee1261a9bc427226b8d6d2"
   integrity sha1-sRf9OiuQEtzM7hJhqbxCcia41tI=
 
-react-native-mock-render@0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/react-native-mock-render/-/react-native-mock-render-0.1.5.tgz#c6c502a0a5f45755b8c4bc19af2e44be794a6eb6"
-  integrity sha512-LzNZo25Ul2S+43nJuIDizn1Aycr/KrGjLeJMV9BwjKDHlo2vrqega5VXoXIFoHg6Qpm85EabsIuHWaoW8Nh55g==
+"react-native-mock-render@git+https://github.com/mrdulin/react-native-mock-render.git#art":
+  version "0.1.9"
+  resolved "git+https://github.com/mrdulin/react-native-mock-render.git#0806b283183bed91f0533bbd80143ef9ee872ba7"
   dependencies:
     create-react-class "^15.6.2"
     cubic-bezier "^0.1.2"


### PR DESCRIPTION
When running `npm run test:rn` on the master branch, the test will fail:
```
FAIL  components/button/__tests__/index.native.test.jsx
  ● Test suite failed to run

    Cannot find module 'art/core/class.js' from 'node_modules/react-native-mock-render/build/components/ART/Path.js'

    Require stack:
      node_modules/react-native-mock-render/build/components/ART/Path.js
      node_modules/react-native-mock-render/build/components/ART/index.js
      node_modules/react-native-mock-render/build/react-native.js
      scripts/jest/setup.js

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:306:11)
      at Object.<anonymous> (node_modules/react-native-mock-render/build/components/ART/Path.js:1:104)
```
Related issues:
https://github.com/Root-App/react-native-mock-render/issues/47
https://github.com/Root-App/react-native-mock-render/pull/89 

PR has not been merged, so fork a repaired version. This is a temporary solution, consider using jest's `react-native` preset instead, need to modify the jest configuration in the `zarm-cli` project.
