### PR TITLE
fix: file-picker children's classname will replace to needsclick. fix…

### DIFF
--- a/components/file-picker/index.tsx
+++ b/components/file-picker/index.tsx
@@ -87,7 +87,7 @@ export default class FilePicker extends PureComponent<FilePickerProps, {}> {
 
     const content = cloneElement(children, {
       onClick: this.handleClick,
-      className: 'needsclick', // 修复加载fastClick库后引起的合成事件问题
+      className: classNames(children.props.className, 'needsclick'), // 修复加载fastClick库后引起的合成事件问题
     });
 
     return (


### PR DESCRIPTION
… #590