### PR TITLE
fix(activity-indicator): 活动指示器size取值与文档不符

### DIFF
--- a/packages/zarm/src/activity-indicator/PropsType.tsx
+++ b/packages/zarm/src/activity-indicator/PropsType.tsx
@@ -1,5 +1,5 @@
 export default interface PropsType {
-  size?: 'lg';
+  size?: 'lg' | 'md';
   strokeWidth?: number;
   percent?: number;
   type?: 'circular' | 'spinner';


### PR DESCRIPTION
https://zarm.design/#/components/activity-indicator