### PR TITLE
feat: button will autoloading when onclick callback return promise

### DIFF
--- a/packages/zarm/src/button/demo.md
+++ b/packages/zarm/src/button/demo.md
@@ -144,6 +144,21 @@ ReactDOM.render(
 );
 ```
 
+## 自动进入 Loading 状态(防重入)
+
+```jsx
+import { Button, Icon } from 'zarm';
+ReactDOM.render(
+  <>
+    {/* 当 Button 的 onClick 回调返回 Promise 对象时, 则自动进入 loading 状态, 待 Promise 执行完毕后恢复(Promise.finally) */}
+    <Button onClick={() => new Promise((resolve) => setTimeout(resolve, 1000 * 3))}>
+      Automatic Loading
+    </Button>
+  </>,
+  mountNode,
+);
+```
+
 ## 链接按钮
 
 ```jsx
@@ -192,19 +207,19 @@ ReactDOM.render(
 
 ## API
 
-| 属性     | 类型                             | 默认值    | 说明                                                                          |
-| :------- | :------------------------------- | :-------- | :---------------------------------------------------------------------------- |
-| theme    | string                           | 'default' | 设置主题，可选值为 `default`、`primary`、`danger`                             |
-| size     | string                           | 'md'      | 设置大小，可选值为 `md`、`lg`、`sm`、`xs`                                     |
-| shape    | string                           | 'radius'  | 设置形状，可选值为 `rect`、`radius`、`round`、`circle`                        |
-| block    | boolean                          | false     | 是否块级元素                                                                  |
-| ghost    | boolean                          | false     | 是否幽灵按钮                                                                  |
-| shadow   | boolean                          | false     | 是否带阴影                                                                    |
-| disabled | boolean                          | false     | 是否禁用                                                                      |
-| loading  | boolean                          | false     | 是否加载中状态                                                                |
-| icon     | ReactNode                        | -         | 设置图标                                                                      |
-| onClick  | MouseEventHandler&lt;Element&gt; | -         | 点击后触发的回调函数                                                          |
-| htmlType | string                           | 'button'  | 设置原生 button 的`type`值，可选值为`button`、`submit`、`reset`               |
-| href     | string                           | -         | 点击跳转的地址，指定此属性`button`的行为和 a 标签一致                         |
-| target   | string                           | -         | 规定在何处打开链接文档，相当于 a 标签的`target`属性，`href`属性存在时生效     |
-| mimeType | string                           | -         | 链接中指向的文档的 mime 类型，相当于 a 标签的`type`属性，`href`属性存在时生效 |
+| 属性     | 类型                             | 默认值    | 说明                                                                                                                          |
+| :------- | :------------------------------- | :-------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| theme    | string                           | 'default' | 设置主题，可选值为 `default`、`primary`、`danger`                                                                             |
+| size     | string                           | 'md'      | 设置大小，可选值为 `md`、`lg`、`sm`、`xs`                                                                                     |
+| shape    | string                           | 'radius'  | 设置形状，可选值为 `rect`、`radius`、`round`、`circle`                                                                        |
+| block    | boolean                          | false     | 是否块级元素                                                                                                                  |
+| ghost    | boolean                          | false     | 是否幽灵按钮                                                                                                                  |
+| shadow   | boolean                          | false     | 是否带阴影                                                                                                                    |
+| disabled | boolean                          | false     | 是否禁用                                                                                                                      |
+| loading  | boolean                          | false     | 是否加载中状态 (不处理点击等事件)                                                                                             |
+| icon     | ReactNode                        | -         | 设置图标                                                                                                                      |
+| onClick  | MouseEventHandler&lt;Element&gt; | -         | 点击后触发的回调函数. 如果 onClick 函数返回 Promise 对象, 则自动进入 loading 状态, 待 Promise 执行完毕后恢复(Promise.finally) |
+| htmlType | string                           | 'button'  | 设置原生 button 的`type`值，可选值为`button`、`submit`、`reset`                                                               |
+| href     | string                           | -         | 点击跳转的地址，指定此属性`button`的行为和 a 标签一致                                                                         |
+| target   | string                           | -         | 规定在何处打开链接文档，相当于 a 标签的`target`属性，`href`属性存在时生效                                                     |
+| mimeType | string                           | -         | 链接中指向的文档的 mime 类型，相当于 a 标签的`type`属性，`href`属性存在时生效                                                 |

--- a/packages/zarm/src/utils/utilityTypes.ts
+++ b/packages/zarm/src/utils/utilityTypes.ts
@@ -7,3 +7,7 @@ export type StringPropertyNames<T> = {
 export type NonFunctionPropertyNames<T> = {
   [K in keyof T]: T[K] extends Function ? never : K;
 }[keyof T];
+
+export type ModifyReturnType<OriginalFN, ReturnType> = OriginalFN extends (...a: infer A) => any
+  ? (...a: A) => ReturnType
+  : never;

--- a/packages/zarm/src/utils/validate.tsx
+++ b/packages/zarm/src/utils/validate.tsx
@@ -17,3 +17,11 @@ export const isNumber = (val: any) => {
 export const isCascader = ({ dataSource }) => {
   return dataSource && dataSource[0] && !isArray(dataSource[0]);
 };
+
+export const isPromise = (obj) => {
+  return (
+    !!obj &&
+    (typeof obj === 'object' || typeof obj === 'function') &&
+    typeof obj.then === 'function'
+  );
+};


### PR DESCRIPTION
# 背景
1. 按钮点击, 快速拖动等用户交互过程中, 会重复执行如 onClick等回调函数, 导致逻辑重复执行, 甚至重复发起请求提交表单
2. 执行 onClick 等回调函数时, 开发需要书写逻辑进行来防重入

# 解决方案
~~### 方案 1:~~
~~onClick={_.debounce(onClick)}, debounce 可以解决快速连续点击问题, 只执行最后一次回调函数, 但onClick 回调中有异步任务时, 仍不能保证不会重复执行~~

### 方案 2:
onClick={new Promise(() => 代码逻辑 )}
当 onClick 回调返回一个 Promise 对象时, Button 自动进入 loading 状态, Promise.finally 之后, 退出 loading 状态
button loading 状态下, 不处理事件

# 其它
用户自行接入 promise.finally polyfill

# TODO
改成 Functional Component

# Ref
https://github.com/then/is-promise/blob/master/index.js
