### PR TITLE
fix: icon-font link url is 404 in https://zarm.design/#/components/icon

### DIFF
--- a/packages/zarm/src/icon/demo.md
+++ b/packages/zarm/src/icon/demo.md
@@ -76,7 +76,7 @@ ReactDOM.render(
 
 ## 自定义 Iconfont 图标
 
-我们提供了一个 createFromIconfont 方法，方便开发者调用在 [iconfont.cn](iconfont.cn) 上自行管理的图标。
+我们提供了一个 createFromIconfont 方法，方便开发者调用在 [iconfont.cn](https://www.iconfont.cn/) 上自行管理的图标。
 
 其本质上是组件在渲染前会自动引入 iconfont.cn 项目中的图标符号集，并且创建了一个 `<use>` 标签来渲染图标的组件。
 


### PR DESCRIPTION
在网站icon组件 自定义 Iconfont 图标小节有一个跳转到阿里 icon-font的地址。目前是相对地址导致了404错误。