### PR TITLE
fix: transition

### DIFF
--- a/packages/zarm/src/transition/Transition.tsx
+++ b/packages/zarm/src/transition/Transition.tsx
@@ -82,7 +82,7 @@ const Transition: React.FC<TransitionProps> = (props) => {
     WebkitAnimationDuration: timeout,
     transitionDuration: timeout,
     WebkitTransitionDuration: timeout,
-    display: (unmounted || exited) && !destroy ? 'none' : undefined,
+    display: (unmounted || exited) && !visible && !destroy ? 'none' : undefined,
   };
 
   const setNodeRef = (node: HTMLElement | null) => {


### PR DESCRIPTION
修复 `visible` 为 `true` 时，`display: none` 判断条件缺失