### PR TITLE
feat(zarm/panel): Improved panel component

### DIFF
--- a/packages/zarm/src/panel/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/zarm/src/panel/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,29 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Panel renders correctly 1`] = `
-<div>
+exports[`Panel snapshots with title and more props 1`] = `
+<div
+  class="za-panel za-panel--bordered"
+>
   <div
-    class="za-panel za-panel--bordered"
+    class="za-panel__header"
   >
     <div
-      class="za-panel__header"
+      class="za-panel__header__title"
     >
-      <div
-        class="za-panel__header__title"
-      >
-        title
-      </div>
-      <div
-        class="za-panel__header__more"
-      >
-        more
-      </div>
+      title
     </div>
     <div
-      class="za-panel__body"
+      class="za-panel__header__more"
     >
-      body
+      more
     </div>
+  </div>
+  <div
+    class="za-panel__body"
+  >
+    body
   </div>
 </div>
 `;

--- a/packages/zarm/src/panel/__tests__/index.test.tsx
+++ b/packages/zarm/src/panel/__tests__/index.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 import { createBEM } from '@zarm-design/bem';
 import React, { useEffect, useRef } from 'react';
 import { defaultConfig } from '../../config-provider/ConfigProvider';
-import Panel, { Ref as PanelRef } from '../index';
+import Panel from '../index';
 
 const bem = createBEM('panel', { prefixCls: defaultConfig.prefixCls });
 
@@ -35,7 +35,7 @@ describe('Panel', () => {
   });
 
   test('should forward ref created by React.createRef() API', (done) => {
-    const ref = React.createRef<PanelRef>();
+    const ref = React.createRef<HTMLDivElement>();
     render(
       <Panel bordered={false} ref={ref}>
         body
@@ -50,7 +50,7 @@ describe('Panel', () => {
   test('should forward ref created by useRef() hook', (done) => {
     expect.assertions(2);
     const TestComp = () => {
-      const ref = useRef<PanelRef>(null);
+      const ref = useRef<HTMLDivElement>(null);
       useEffect(() => {
         if (ref.current) {
           expect(ref.current.className).toEqual('za-panel');

--- a/packages/zarm/src/panel/__tests__/index.test.tsx
+++ b/packages/zarm/src/panel/__tests__/index.test.tsx
@@ -33,4 +33,17 @@ describe('Panel', () => {
       padding: 'var(--header-padding)',
     });
   });
+
+  test('should forward ref', (done) => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(
+      <Panel bordered={false} ref={ref}>
+        body
+      </Panel>,
+    );
+    if (!ref.current) return done('ref.current does not exist');
+    expect(ref.current.className).toEqual('za-panel');
+    expect(ref.current.nodeName.toLocaleLowerCase()).toBe('div');
+    done();
+  });
 });

--- a/packages/zarm/src/panel/__tests__/index.test.tsx
+++ b/packages/zarm/src/panel/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import { createBEM } from '@zarm-design/bem';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { defaultConfig } from '../../config-provider/ConfigProvider';
 import Panel from '../index';
 
@@ -34,7 +34,7 @@ describe('Panel', () => {
     });
   });
 
-  test('should forward ref', (done) => {
+  test('should forward ref created by React.createRef() API', (done) => {
     const ref = React.createRef<HTMLDivElement>();
     render(
       <Panel bordered={false} ref={ref}>
@@ -45,5 +45,25 @@ describe('Panel', () => {
     expect(ref.current.className).toEqual('za-panel');
     expect(ref.current.nodeName.toLocaleLowerCase()).toBe('div');
     done();
+  });
+
+  test('should forward ref created by useRef() hook', (done) => {
+    expect.assertions(2)
+    const TestComp = () => {
+      const ref = useRef<HTMLDivElement>(null);
+      useEffect(() => {
+        if (ref.current) {
+          expect(ref.current.className).toEqual('za-panel');
+          expect(ref.current.nodeName.toLocaleLowerCase()).toBe('div');
+          done();
+        }
+      }, []);
+      return (
+        <Panel bordered={false} ref={ref}>
+          body
+        </Panel>
+      );
+    };
+    render(<TestComp />);
   });
 });

--- a/packages/zarm/src/panel/__tests__/index.test.tsx
+++ b/packages/zarm/src/panel/__tests__/index.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 import { createBEM } from '@zarm-design/bem';
 import React, { useEffect, useRef } from 'react';
 import { defaultConfig } from '../../config-provider/ConfigProvider';
-import Panel from '../index';
+import Panel, { Ref as PanelRef } from '../index';
 
 const bem = createBEM('panel', { prefixCls: defaultConfig.prefixCls });
 
@@ -35,7 +35,7 @@ describe('Panel', () => {
   });
 
   test('should forward ref created by React.createRef() API', (done) => {
-    const ref = React.createRef<HTMLDivElement>();
+    const ref = React.createRef<PanelRef>();
     render(
       <Panel bordered={false} ref={ref}>
         body
@@ -48,9 +48,9 @@ describe('Panel', () => {
   });
 
   test('should forward ref created by useRef() hook', (done) => {
-    expect.assertions(2)
+    expect.assertions(2);
     const TestComp = () => {
-      const ref = useRef<HTMLDivElement>(null);
+      const ref = useRef<PanelRef>(null);
       useEffect(() => {
         if (ref.current) {
           expect(ref.current.className).toEqual('za-panel');

--- a/packages/zarm/src/panel/__tests__/index.test.tsx
+++ b/packages/zarm/src/panel/__tests__/index.test.tsx
@@ -1,14 +1,36 @@
-import React from 'react';
 import { render } from '@testing-library/react';
+import { createBEM } from '@zarm-design/bem';
+import React from 'react';
+import { defaultConfig } from '../../config-provider/ConfigProvider';
 import Panel from '../index';
 
+const bem = createBEM('panel', { prefixCls: defaultConfig.prefixCls });
+
 describe('Panel', () => {
-  it('renders correctly', () => {
-    const { container } = render(
+  test('snapshots with title and more props', () => {
+    const { asFragment } = render(
       <Panel title="title" more="more">
         body
       </Panel>,
     );
-    expect(container).toMatchSnapshot();
+    expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  test('should not render header if do not have title and more props', () => {
+    const { container } = render(<Panel>body</Panel>);
+    expect(container.children).toHaveLength(1);
+    expect(container.querySelector(`.${bem('header')}`)).not.toBeInTheDocument();
+    expect(container.querySelector(`.${bem('body')}`)).toBeInTheDocument();
+  });
+
+  test('should accept custom css vars', () => {
+    const { container } = render(
+      <Panel title="title" style={{ '--header-padding': 0 }}>
+        body
+      </Panel>,
+    );
+    expect(container.querySelector(`.${bem('header')}`)).toHaveStyle({
+      padding: 'var(--header-padding)',
+    });
   });
 });

--- a/packages/zarm/src/panel/index.tsx
+++ b/packages/zarm/src/panel/index.tsx
@@ -19,10 +19,12 @@ export type PanelProps = Omit<React.ComponentPropsWithRef<'div'>, keyof BasePane
     style?: React.CSSProperties & Partial<PanelCssVars>;
   };
 
-const Panel = React.forwardRef<HTMLDivElement, PanelProps>((props, ref) => {
+export type Ref = HTMLDivElement;
+
+const Panel = React.forwardRef<Ref, PanelProps>((props, ref) => {
   const { className, title, more, spacing, bordered, children, ...restProps } = props;
 
-  const panelRef = useRef<HTMLDivElement>();
+  const panelRef = useRef<Ref>();
   useImperativeHandle(ref, () => panelRef.current);
 
   const { prefixCls } = React.useContext(ConfigContext);

--- a/packages/zarm/src/panel/index.tsx
+++ b/packages/zarm/src/panel/index.tsx
@@ -1,7 +1,6 @@
 import { createBEM } from '@zarm-design/bem';
 import React, { useImperativeHandle, useRef } from 'react';
 import { ConfigContext } from '../config-provider';
-import type { HTMLProps } from '../utils/utilityTypes';
 import type { BasePanelProps } from './interface';
 
 export interface PanelCssVars {
@@ -15,9 +14,10 @@ export interface PanelCssVars {
   '--spacing-padding-horizontal'?: React.CSSProperties['padding'];
 }
 
-export type PanelProps = Omit<React.ComponentPropsWithRef<'div'>, keyof BasePanelProps> &
-  Partial<BasePanelProps> &
-  HTMLProps<PanelCssVars>;
+export type PanelProps = Omit<React.ComponentPropsWithRef<'div'>, keyof BasePanelProps | 'style'> &
+  Partial<BasePanelProps> & {
+    style?: React.CSSProperties & Partial<PanelCssVars>;
+  };
 
 const Panel = React.forwardRef<HTMLDivElement, PanelProps>((props, ref) => {
   const { className, title, more, spacing, bordered, children, ...restProps } = props;

--- a/packages/zarm/src/panel/index.tsx
+++ b/packages/zarm/src/panel/index.tsx
@@ -16,7 +16,7 @@ export interface PanelCssVars {
 }
 
 export type PanelProps = Omit<React.ComponentPropsWithRef<'div'>, keyof BasePanelProps> &
-  BasePanelProps &
+  Partial<BasePanelProps> &
   HTMLProps<PanelCssVars>;
 
 const Panel = React.forwardRef<HTMLDivElement, PanelProps>((props, ref) => {

--- a/packages/zarm/src/panel/index.tsx
+++ b/packages/zarm/src/panel/index.tsx
@@ -1,5 +1,5 @@
 import { createBEM } from '@zarm-design/bem';
-import React from 'react';
+import React, { useImperativeHandle, useRef } from 'react';
 import { ConfigContext } from '../config-provider';
 import { HTMLProps } from '../utils/utilityTypes';
 import { BasePanelProps } from './interface';
@@ -22,7 +22,9 @@ export type PanelProps = Omit<React.ComponentPropsWithRef<'div'>, keyof BasePane
 const Panel = React.forwardRef<HTMLDivElement, PanelProps>((props, ref) => {
   const { className, title, more, spacing, bordered, children, ...restProps } = props;
 
-  const panelRef = ref || React.createRef<HTMLDivElement>();
+  const panelRef = useRef<HTMLDivElement>();
+  useImperativeHandle(ref, () => panelRef.current);
+
   const { prefixCls } = React.useContext(ConfigContext);
   const bem = createBEM('panel', { prefixCls });
 

--- a/packages/zarm/src/panel/index.tsx
+++ b/packages/zarm/src/panel/index.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
 import { createBEM } from '@zarm-design/bem';
+import React from 'react';
 import { ConfigContext } from '../config-provider';
-import type { BasePanelProps } from './interface';
-import type { HTMLProps } from '../utils/utilityTypes';
+import { HTMLProps } from '../utils/utilityTypes';
+import { BasePanelProps } from './interface';
 
 export interface PanelCssVars {
   '--header-padding'?: React.CSSProperties['padding'];
@@ -15,7 +15,9 @@ export interface PanelCssVars {
   '--spacing-padding-horizontal'?: React.CSSProperties['padding'];
 }
 
-export type PanelProps = BasePanelProps & React.PropsWithChildren<HTMLProps<PanelCssVars>>;
+export type PanelProps = Omit<React.ComponentPropsWithRef<'div'>, keyof BasePanelProps> &
+  BasePanelProps &
+  HTMLProps<PanelCssVars>;
 
 const Panel = React.forwardRef<HTMLDivElement, PanelProps>((props, ref) => {
   const { className, title, more, spacing, bordered, children, ...restProps } = props;
@@ -28,10 +30,12 @@ const Panel = React.forwardRef<HTMLDivElement, PanelProps>((props, ref) => {
 
   return (
     <div className={cls} ref={panelRef} {...restProps}>
-      <div className={bem('header')}>
-        {title && <div className={bem('header__title')}>{title}</div>}
-        {more && <div className={bem('header__more')}>{more}</div>}
-      </div>
+      {(title || more) && (
+        <div className={bem('header')}>
+          {title && <div className={bem('header__title')}>{title}</div>}
+          {more && <div className={bem('header__more')}>{more}</div>}
+        </div>
+      )}
       <div className={bem('body')}>{children}</div>
     </div>
   );

--- a/packages/zarm/src/panel/index.tsx
+++ b/packages/zarm/src/panel/index.tsx
@@ -1,7 +1,8 @@
 import { createBEM } from '@zarm-design/bem';
-import React, { useImperativeHandle, useRef } from 'react';
+import React from 'react';
 import { ConfigContext } from '../config-provider';
 import type { BasePanelProps } from './interface';
+
 
 export interface PanelCssVars {
   '--header-padding'?: React.CSSProperties['padding'];
@@ -14,18 +15,14 @@ export interface PanelCssVars {
   '--spacing-padding-horizontal'?: React.CSSProperties['padding'];
 }
 
-export type PanelProps = Omit<React.ComponentPropsWithRef<'div'>, keyof BasePanelProps | 'style'> &
-  Partial<BasePanelProps> & {
-    style?: React.CSSProperties & Partial<PanelCssVars>;
+export type PanelProps = Omit<React.ComponentPropsWithRef<'div'>, 'title'> &
+  BasePanelProps & {
+    style?: Partial<PanelCssVars>;
   };
 
-export type Ref = HTMLDivElement;
 
-const Panel = React.forwardRef<Ref, PanelProps>((props, ref) => {
+const Panel = React.forwardRef<HTMLDivElement, PanelProps>((props, ref) => {
   const { className, title, more, spacing, bordered, children, ...restProps } = props;
-
-  const panelRef = useRef<Ref>();
-  useImperativeHandle(ref, () => panelRef.current);
 
   const { prefixCls } = React.useContext(ConfigContext);
   const bem = createBEM('panel', { prefixCls });
@@ -33,7 +30,7 @@ const Panel = React.forwardRef<Ref, PanelProps>((props, ref) => {
   const cls = bem([{ spacing, bordered }, className]);
 
   return (
-    <div className={cls} ref={panelRef} {...restProps}>
+    <div className={cls} ref={ref} {...restProps}>
       {(title || more) && (
         <div className={bem('header')}>
           {title && <div className={bem('header__title')}>{title}</div>}

--- a/packages/zarm/src/panel/index.tsx
+++ b/packages/zarm/src/panel/index.tsx
@@ -1,8 +1,8 @@
 import { createBEM } from '@zarm-design/bem';
 import React, { useImperativeHandle, useRef } from 'react';
 import { ConfigContext } from '../config-provider';
-import { HTMLProps } from '../utils/utilityTypes';
-import { BasePanelProps } from './interface';
+import type { HTMLProps } from '../utils/utilityTypes';
+import type { BasePanelProps } from './interface';
 
 export interface PanelCssVars {
   '--header-padding'?: React.CSSProperties['padding'];

--- a/packages/zarm/src/panel/interface.ts
+++ b/packages/zarm/src/panel/interface.ts
@@ -1,8 +1,8 @@
 import { ReactNode } from 'react';
 
 export interface BasePanelProps {
-  title: ReactNode;
-  more: ReactNode;
-  spacing: boolean;
-  bordered: boolean;
+  title?: ReactNode;
+  more?: ReactNode;
+  spacing?: boolean;
+  bordered?: boolean;
 }

--- a/packages/zarm/src/panel/interface.ts
+++ b/packages/zarm/src/panel/interface.ts
@@ -1,8 +1,8 @@
 import { ReactNode } from 'react';
 
 export interface BasePanelProps {
-  title?: ReactNode;
-  more?: ReactNode;
-  spacing?: boolean;
-  bordered?: boolean;
+  title: ReactNode;
+  more: ReactNode;
+  spacing: boolean;
+  bordered: boolean;
 }


### PR DESCRIPTION
1. 没有`title`和`more` props时，不渲染`header`节点
2. 添加更多测试
3. 使用[useImperativeHandle(ref, createHandle, dependencies?)](https://react.dev/reference/react/useImperativeHandle#useimperativehandle)将ref暴露给父组件
4. 调整TS类型，导出`type Ref = HTMLDivElement`类型，

ref在组件内被传递给哪个组件或者HTML element，客户端如果不看代码或者TS类型报错之前，是不知道的，导出`Ref`类型