### PR TITLE
fix：修复Carousel组件部分IOS设备下无法滑动的问题

### DIFF
--- a/packages/zarm/src/carousel/index.tsx
+++ b/packages/zarm/src/carousel/index.tsx
@@ -12,6 +12,7 @@ import React, {
 import type { CSSProperties } from 'react';
 import { createBEM } from '@zarm-design/bem';
 import { useDrag } from '@use-gesture/react';
+import { useEventListener } from 'ahooks';
 import type { BaseCarouselProps } from './interface';
 import Events from '../utils/events';
 import { ConfigContext } from '../config-provider';
@@ -83,12 +84,18 @@ const Carousel = forwardRef<CarouselHTMLElement, CarouselProps>((props, ref) => 
   const isVertical = direction === 'vertical';
 
   const carouselRef = (ref as any) || React.createRef<CarouselHTMLElement>();
+  const carouselDomRef = useRef<HTMLDivElement>(null);
   const carouselItemsRef = useRef<HTMLDivElement>(null);
 
   const translateXRef = useRef(0);
   const translateYRef = useRef(0);
 
   const count = useMemo(() => Children.count(children), [children]);
+
+  // 监听原生touchstart，可以在ios部分设备下解决未在可视区域内的元素无法触发onTouchStart事件的问题
+  useEventListener('touchstart', () => { }, {
+    target: carouselDomRef
+  })
 
   // 处理节点（首尾拼接）
   const carouselItems = useMemo(() => {
@@ -207,7 +214,7 @@ const Carousel = forwardRef<CarouselHTMLElement, CarouselProps>((props, ref) => 
       let { activeIndex } = stateRef.current;
       if (onMoving.current) {
         if (activeIndex <= 0) {
-         onJumpTo(0);
+          onJumpTo(0);
         } else if (activeIndex >= count - 1) {
           onJumpTo(count - 1);
         }
@@ -334,7 +341,10 @@ const Carousel = forwardRef<CarouselHTMLElement, CarouselProps>((props, ref) => 
   return (
     <div className={cls} style={style} ref={carouselRef} {...bind()}>
       <div
-        ref={carouselItemsRef}
+        ref={el => {
+          carouselItemsRef.current = el;
+          carouselDomRef.current = el;
+        }}
         className={bem('items')}
         onTransitionEnd={transitionEnd}
         style={itemsStyle}


### PR DESCRIPTION
问题：在部分IOS设备上，当Carousel组件在页面加载时未出现在可视区域内时，滑动无效
分析：useDrag函数方法返回了onTouchStart函数，并绑定到了div容器上；经过实测，部分IOS设备无法触发onTouchStart事件，导致绑定的事件失效，从而无法触发useDrag函数，导致滑动逻辑无法进行；
解决：通过addEventListner监听touchstart事件，可以让元素触发onTouchStart事件。