### PR TITLE
chore: optimize zarm icon export module type

### DIFF
--- a/packages/zarm-icons/package.json
+++ b/packages/zarm-icons/package.json
@@ -5,9 +5,18 @@
   "license": "MIT",
   "author": "jerome.lin@zhongan.com",
   "exports": {
-    ".": "./lib/index.js",
-    "./style": "./lib/style/index.scss",
-    "./style/font": "./lib/font/style/icon.scss"
+    ".": {
+      "import": "./es/index.js",
+      "default": "./lib/index.js"
+    },
+    "./style": {
+      "import": "./es/style/index.scss",
+      "default": "./lib/style/index.scss"
+    },
+    "./style/font": {
+      "import": "./es/font/style/icon.scss",
+      "default": "./lib/font/style/icon.scss"
+    }
   },
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
The current Zarm export configuration causes references to resources in the `lib` instead of `es` when using the ES module, resulting in failed tree shaking.

> [exports field is preferred over other package entry fields like main, module, browser or custom ones.](https://webpack.js.org/guides/package-exports/#notes-about-ordering)