### PR TITLE
Fix carousel width hight

### DIFF
--- a/packages/zarm/src/carousel/index.tsx
+++ b/packages/zarm/src/carousel/index.tsx
@@ -16,6 +16,7 @@ import type { BaseCarouselProps } from './interface';
 import Events from '../utils/events';
 import { ConfigContext } from '../config-provider';
 import type { HTMLProps } from '../utils/utilityTypes';
+import { getOffsetSize } from '../utils/dom';
 
 export interface CarouselCssVars {
   '--pagination-margin'?: React.CSSProperties['right' | 'bottom'];
@@ -140,8 +141,9 @@ const Carousel = forwardRef<CarouselHTMLElement, CarouselProps>((props, ref) => 
     const { activeIndex, activeIndexChanged } = stateRef.current;
     const dom = carouselItemsRef.current;
     const index = loop ? activeIndex + 1 : activeIndex;
-    translateXRef.current = -dom!.offsetWidth * index;
-    translateYRef.current = -dom!.offsetHeight * index;
+    const size = getOffsetSize(dom);
+    translateXRef.current = -size.width * (index + 1);
+    translateYRef.current = -size.height * index;
     doTransition({ x: translateXRef.current, y: translateYRef.current }, 0);
     if (activeIndexChanged) {
       onChangeEnd?.(activeIndex);
@@ -155,8 +157,9 @@ const Carousel = forwardRef<CarouselHTMLElement, CarouselProps>((props, ref) => 
       const previousIndex = stateRef.current.activeIndex;
       const activeIndexChanged = previousIndex !== index;
       const num = loop ? 1 : 0;
-      translateXRef.current = -dom!.offsetWidth * (index + num);
-      translateYRef.current = -dom!.offsetHeight * (index + num);
+      const size = getOffsetSize(dom);
+      translateXRef.current = -size.width * (index + num);
+      translateYRef.current = -size.height * (index + num);
       doTransition(
         { x: translateXRef.current, y: translateYRef.current },
         animationDurationNum
@@ -235,10 +238,10 @@ const Carousel = forwardRef<CarouselHTMLElement, CarouselProps>((props, ref) => 
       }
       if (state.last) {
         const dom = carouselItemsRef.current;
-
+        const size = getOffsetSize(dom);
         const ratio = !isVertical
-          ? Math.abs(offsetX / dom!.offsetWidth)
-          : Math.abs(offsetY / dom!.offsetHeight);
+          ? Math.abs(offsetX / size.width)
+          : Math.abs(offsetY / size.height);
         // 判断滑动临界点
         // 1.滑动距离超过0，且滑动距离和父容器长度之比超过moveDistanceRatio
         // 2.滑动释放时间差低于moveTimeSpan

--- a/packages/zarm/src/carousel/index.tsx
+++ b/packages/zarm/src/carousel/index.tsx
@@ -16,7 +16,7 @@ import type { BaseCarouselProps } from './interface';
 import Events from '../utils/events';
 import { ConfigContext } from '../config-provider';
 import type { HTMLProps } from '../utils/utilityTypes';
-import { getOffsetSize } from '../utils/dom';
+import { getBoundingClientRect } from '../utils/dom';
 
 export interface CarouselCssVars {
   '--pagination-margin'?: React.CSSProperties['right' | 'bottom'];
@@ -141,7 +141,7 @@ const Carousel = forwardRef<CarouselHTMLElement, CarouselProps>((props, ref) => 
     const { activeIndex, activeIndexChanged } = stateRef.current;
     const dom = carouselItemsRef.current;
     const index = loop ? activeIndex + 1 : activeIndex;
-    const size = getOffsetSize(dom);
+    const size = getBoundingClientRect(dom);
     translateXRef.current = -size.width * index;
     translateYRef.current = -size.height * index;
     doTransition({ x: translateXRef.current, y: translateYRef.current }, 0);
@@ -157,7 +157,7 @@ const Carousel = forwardRef<CarouselHTMLElement, CarouselProps>((props, ref) => 
       const previousIndex = stateRef.current.activeIndex;
       const activeIndexChanged = previousIndex !== index;
       const num = loop ? 1 : 0;
-      const size = getOffsetSize(dom);
+      const size = getBoundingClientRect(dom);
       translateXRef.current = -size.width * (index + num);
       translateYRef.current = -size.height * (index + num);
       doTransition(
@@ -238,7 +238,7 @@ const Carousel = forwardRef<CarouselHTMLElement, CarouselProps>((props, ref) => 
       }
       if (state.last) {
         const dom = carouselItemsRef.current;
-        const size = getOffsetSize(dom);
+        const size = getBoundingClientRect(dom);
         const ratio = !isVertical
           ? Math.abs(offsetX / size.width)
           : Math.abs(offsetY / size.height);

--- a/packages/zarm/src/carousel/index.tsx
+++ b/packages/zarm/src/carousel/index.tsx
@@ -142,7 +142,7 @@ const Carousel = forwardRef<CarouselHTMLElement, CarouselProps>((props, ref) => 
     const dom = carouselItemsRef.current;
     const index = loop ? activeIndex + 1 : activeIndex;
     const size = getOffsetSize(dom);
-    translateXRef.current = -size.width * (index + 1);
+    translateXRef.current = -size.width * index;
     translateYRef.current = -size.height * index;
     doTransition({ x: translateXRef.current, y: translateYRef.current }, 0);
     if (activeIndexChanged) {

--- a/packages/zarm/src/utils/dom/dom.ts
+++ b/packages/zarm/src/utils/dom/dom.ts
@@ -45,26 +45,6 @@ export const getBoundingClientRect = (
   };
 };
 
-
-/**
- * 获取元素size
- */
-export const getOffsetSize = (ele: HTMLElement) => {
-  const rect = getBoundingClientRect(ele);
-
-  if (rect.width && rect.height) {
-    return rect;
-  }
-
-  const { offsetWidth, offsetHeight } = ele;
-
-  if (offsetWidth && offsetHeight) {
-    return { width: offsetWidth, height: offsetHeight };
-  }
-
-  return { width: 0, height: 0 };
-}
-
 export const isNumeric = (n: any): boolean => {
   return n !== '' && !Number.isNaN(parseFloat(n)) && Number.isFinite(n);
 };

--- a/packages/zarm/src/utils/dom/dom.ts
+++ b/packages/zarm/src/utils/dom/dom.ts
@@ -45,6 +45,24 @@ export const getBoundingClientRect = (
   };
 };
 
+
+/**
+ * 获取元素size
+ */
+export const getOffsetSize = (ele: HTMLElement) => {
+  const rect = getBoundingClientRect(ele);
+
+  if (rect.width && rect.height) {
+    return rect;
+  }
+
+  const { offsetWidth, offsetHeight } = ele;
+
+  if (offsetWidth && offsetHeight) {
+    return { width: offsetWidth, height: offsetHeight };
+  }
+}
+
 export const isNumeric = (n: any): boolean => {
   return n !== '' && !Number.isNaN(parseFloat(n)) && Number.isFinite(n);
 };

--- a/packages/zarm/src/utils/dom/dom.ts
+++ b/packages/zarm/src/utils/dom/dom.ts
@@ -61,6 +61,8 @@ export const getOffsetSize = (ele: HTMLElement) => {
   if (offsetWidth && offsetHeight) {
     return { width: offsetWidth, height: offsetHeight };
   }
+
+  return { width: 0, height: 0 };
 }
 
 export const isNumeric = (n: any): boolean => {


### PR DESCRIPTION
修复Carousel组件宽高不精确问题。原offsetWidth offsetHeight计算不准确，在展示时内容会有像素偏差，下一个轮播内容会漏出一点。