### PR TITLE
docs(carousel): incorrect directiopn props api

### DIFF
--- a/packages/zarm/src/carousel/demo.md
+++ b/packages/zarm/src/carousel/demo.md
@@ -170,7 +170,7 @@ ReactDOM.render(
 
 | 属性                 | 类型                          | 默认值 | 说明                                           |
 | :------------------- | :---------------------------- | :----- | :--------------------------------------------- |
-| direction            | string                        | 'left' | 滑动方向，可选值 `left`、`right`、`up`、`down` |
+| direction            | string                        | 'horizontal' | 滑动方向，可选值 `vertical`、`horizontal`|
 | height               | number \| string              | 160    | 设置轮播区域高度                               |
 | activeIndex          | number                        | 0      | 当前页面的索引                                 |
 | loop                 | boolean                       | false  | 是否循环                                       |


### PR DESCRIPTION
<img width="806" alt="企业微信截图_eae9ccbb-cbce-4949-9020-5f051e88ba01" src="https://github.com/user-attachments/assets/3ad66cec-0639-4b3e-9678-a3af1a0f2fbe" />
<img width="1316" alt="企业微信截图_fb59ee50-3a68-4889-b792-5f4206ea20f8" src="https://github.com/user-attachments/assets/a7ec61f8-05e8-4c5c-b000-f11287795db6" />

