### PR TITLE
fix: Reduce inertial scrolling to fix picker selection bug

### DIFF
--- a/packages/zarm/src/wheel/index.ts
+++ b/packages/zarm/src/wheel/index.ts
@@ -1,6 +1,6 @@
 import Wheel from './Wheel';
 
-export type { WheelProps, WheelCssVars } from './Wheel';
 export type { WheelItem, WheelValue } from './interface';
+export type { WheelCssVars, WheelProps, WheelRef } from './Wheel';
 
 export default Wheel;


### PR DESCRIPTION
### 减少惯性滚动以修复选择器选择错误

#### 标题：修复[Issue #1160](https://github.com/ZhongAnTech/zarm/issues/1160)：优化惯性滚动以改善交互体验

#### 主要变更：
- 实时计算bsscroll的滚动y给selectIndex赋值代替使用getSelectedIndex，实时计算当前位置，同时尽量避免过多的性能开销。
- 修改了滚动参数，通过降低惯性滚动的方式，在交互上尽可能避免出现滚动引起的触发回调问题。
- 通过暴露wheelRef，使得Picker的value和items实时变更。
