### PR TITLE
fix: 2.x dart sass support

### DIFF
--- a/packages/zarm/src/activity-indicator/style/component.scss
+++ b/packages/zarm/src/activity-indicator/style/component.scss
@@ -52,8 +52,8 @@ $activity-indicator-spinner-count : 12;
         height: 100%;
 
         &:nth-of-type(#{$i}) {
-          transform: rotate($i * (360 / $activity-indicator-spinner-count) * 1deg);
-          opacity: $i / $activity-indicator-spinner-count;
+          transform: rotate(calc($i * (360 / $activity-indicator-spinner-count) * 1deg));
+          opacity: calc($i / $activity-indicator-spinner-count);
         }
 
         &::before {


### PR DESCRIPTION
fix: Dart Sass deprecated when using / for  division outside of calc()